### PR TITLE
Add --no-merges flag when fetching for commits

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -212,7 +212,7 @@ func parseCommitList(out string) ([]Commit, error) {
 
 // Commits ...
 func Commits(repoDir string) ([]Commit, error) {
-	cmd := command.New("git", "log", `--pretty=format:commit: %H%ndate: %ct%nauthor: %an%nmessage: %s`).SetDir(repoDir)
+	cmd := command.New("git", "log", `--no-merges --pretty=format:commit: %H%ndate: %ct%nauthor: %an%nmessage: %s`).SetDir(repoDir)
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		return nil, errors.WithStack(fmt.Errorf("%s failed: %s", cmd.PrintableCommandArgs(), out))


### PR DESCRIPTION
### Checklist
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context
Removes merge commits from changelog list

Resolves: #3 

### Changes
- Add `--no-merges` flag to git command

### Decisions
Since merge commits are not relevant for most users, this is going to be hardcoded.